### PR TITLE
webpack CLI fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
     "private": true,
     "scripts": {
         "dev": "npm run development",
-        "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "development": "cross-env NODE_ENV=development node_modules/webpack-cli/bin/cli.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
         "watch": "npm run development -- --watch",
         "watch-poll": "npm run watch -- --watch-poll",
         "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
         "prod": "npm run production",
-        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+        "production": "cross-env NODE_ENV=production node_modules/webpack-cli/bin/cli.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "devDependencies": {
         "autoprefixer": "^9.7.6",
@@ -17,7 +17,10 @@
         "postcss-nested": "^4.2.1",
         "postcss-preset-env": "^6.7.0",
         "tailwindcss": "^1.8.0",
-        "vue-template-compiler": "^2.6.12"
+        "vue-template-compiler": "^2.6.12",
+        "webpack-dev-server": "^3.1.2",
+        "webpack-cli": "^3.1.2",
+        "webpack": "^4.5.0"
     },
     "dependencies": {
         "@tailwindcss/typography": "^0.2.0"


### PR DESCRIPTION
Updated the package.json file to use webpack CLI (which is required after webpack 4.X)

This will allow new users to be able to correctly run "npm install" and the dev/prod scripts.