### PR TITLE
Added `entities` modifier to code block

### DIFF
--- a/resources/views/blog/show.antlers.html
+++ b/resources/views/blog/show.antlers.html
@@ -26,7 +26,7 @@
             {{ if type == "text" }}
                 {{ text }}
             {{ elseif type == "code_block" }}
-<pre class="language-{{ mode ?? 'php' }} rounded"><code>{{ code }}</code></pre>
+<pre class="language-{{ mode ?? 'php' }} rounded"><code>{{ code | entities }}</code></pre>
             {{ elseif type == "image" }}
                 <figure>
                     <img src="{{ image }}" alt="{{ caption }}" />


### PR DESCRIPTION
If you output HTML here (inside the code block) then it gets rendered by the browser rather than outputting it. Added an `entities` modifier means the user sees the HTML itself, as you'd expect in a code block.