### PR TITLE
Small fix to JSON-LD syntax in layout

### DIFF
--- a/resources/views/layout.antlers.html
+++ b/resources/views/layout.antlers.html
@@ -15,8 +15,8 @@
                 "@type": "Person",
                 "name": "{{ author:name }}"
               },
-              "datePublished": "{{ date format='Y-m-d' }}",
-              "description": "{{ intro | strip_tags | entities }}",
+              "datePublished": "{{ date format="Y-m-d" }}",
+              "description": "{{ intro | strip_tags | entities }}"
             }
         </script>
         <link rel="stylesheet" href="{{ mix src='css/tailwind.css' }}">

--- a/resources/views/layout.antlers.html
+++ b/resources/views/layout.antlers.html
@@ -15,7 +15,7 @@
                 "@type": "Person",
                 "name": "{{ author:name }}"
               },
-              "datePublished": "{{ date format="Y-m-d" }}",
+              "datePublished": "{{ date format='Y-m-d' }}",
               "description": "{{ intro | strip_tags | entities }}",
             }
         </script>


### PR DESCRIPTION
Small fix to JSON-LD syntax 

was getting this in google search console 

Parse error: Missing "}" symbol or object member name