### PR TITLE
Drop CLI version warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,5 @@
             "name": "Starter Kit: Starters Creek",
             "description": "Statamic Starter Kit: Starters"
         }
-    },
-    "scripts": {
-        "post-create-project-cmd": [
-            "@php upgrade-cli-notice.php"
-        ]
     }
 }

--- a/upgrade-cli-notice.php
+++ b/upgrade-cli-notice.php
@@ -1,9 +1,0 @@
-<?php
-
-function printError($message) {
-    echo "\033[41;37m{$message}\033[0;37m\n";
-}
-
-printError('Old statamic/cli installer detected!');
-printError('Please upgrade to the latest cli installer and re-install your starter kit.');
-printError('https://github.com/statamic/cli');


### PR DESCRIPTION
This pull request removes the CLI version warnings which were shown to users when they installed starter kits "the old way", using Composer's `create-project` command.

Users will still get out-of-date warnings when they're not using the latest version of the CLI (statamic/cli#45). 
